### PR TITLE
Fix broken close icon in Drawer component

### DIFF
--- a/web/src/lib/components/Drawer.svelte
+++ b/web/src/lib/components/Drawer.svelte
@@ -46,7 +46,12 @@
 	>
 		<header class="drawer-header">
 			<h2>{contribution.title ?? contribution.id}</h2>
-			<button class="close-btn" onclick={onClose}>\u00d7</button>
+			<button class="close-btn" onclick={onClose} aria-label="Close">
+				<svg width="16" height="16" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+					<line x1="3" y1="3" x2="13" y2="13" />
+					<line x1="13" y1="3" x2="3" y2="13" />
+				</svg>
+			</button>
 		</header>
 		<div class="drawer-content">
 			<ComponentLoader {contribution} />


### PR DESCRIPTION
## Summary
- Replace broken `×` (U+00D7) character in the Drawer close button with an inline SVG icon
- Ensures consistent rendering across all fonts and browsers
- Adds `aria-label="Close"` for accessibility

Fixes #2

## Test plan
- [ ] Open the chat drawer and verify the close button displays a clean X icon
- [ ] Verify the close button still functions (click to dismiss)
- [ ] Check other drawers for consistent rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)